### PR TITLE
fix UEFI disks

### DIFF
--- a/LINSTORPlugin.pm
+++ b/LINSTORPlugin.pm
@@ -316,6 +316,9 @@ sub clone_image {
 sub alloc_image {
     my ( $class, $storeid, $scfg, $vmid, $fmt, $name, $size ) = @_;
 
+    my $min_kib = 5*1024;
+    $size = $min_kib unless $size > $min_kib;
+
     # check if it is the controller, which always has exactly "disk-1"
     my $retname = $name;
     if ( !defined($name) ) {


### PR DESCRIPTION
When one configures an UEFI system and puts the "UEFI disk" on DRBD
storage, it fails as PVE creates a very tiny disk (~160K). Due to
rounding this might even work on LVM, but failed on ZFS. Mitigate that
by using a minimum size of 5M. That is enough for DRBD.

Fixes #43 